### PR TITLE
Fix error: Class ‘Template’ not found, and a minor defect in library/renrenoauth.php

### DIFF
--- a/library/renrenoauth.php
+++ b/library/renrenoauth.php
@@ -50,7 +50,7 @@ class RenrenOAuth
 		    "client_secret" => $this->m_secret,
 	   	);
 
-		return httpRequest ( $this->accessTokenURL (), $request, 2 );
+		return httpRequest ( self::ACCESS_TOKEN_URL , $request, 2 );
 	}
 
  

--- a/modules/init/Loader.php
+++ b/modules/init/Loader.php
@@ -17,6 +17,12 @@ class Loader
 	
 	private function __construct()
 	{
+	    /*** nullify any existing autoloads ***/
+        spl_autoload_register(null, false);
+
+        /*** specify extensions that may be loaded ***/
+        spl_autoload_extensions('.php');
+        
 		spl_autoload_register ( array ($this, 'init' ) );
 		spl_autoload_register ( array ($this, 'helper' ) );
 		spl_autoload_register ( array ($this, 'target' ) );
@@ -35,38 +41,48 @@ class Loader
 	protected function init($clazz)
 	{
 		$dir = BASE_PATH . '/modules/init';
-		set_include_path ( $dir );
-		spl_autoload_extensions ( '.php' );
-		spl_autoload ( $clazz );
+		$file = "$dir/$clazz.php";
+		if (!file_exists($file))
+        {
+            return false;
+        }
+        include $file;
 	}
 
 	protected function helper($clazz)
 	{
 		$dir = BASE_PATH . '/helper';
 		$this->splitClazz( $clazz , $dir);
-		set_include_path ( $dir );
-		spl_autoload_extensions('.php');
-		spl_autoload($clazz);
+		$file = "$dir/$clazz.php";
+		if (!file_exists($file))
+        {
+            return false;
+        }
+        include $file;
 	}
 
 	protected function target($clazz) 
 	{
 		$dir = BASE_PATH. '/modules/target';
 		$this->splitClazz($clazz,$dir);	 
-		
-		set_include_path($dir);
-		spl_autoload_extensions('.php');
-		spl_autoload($clazz);
+		$file = "$dir/$clazz.php";
+		if (!file_exists($file))
+        {
+            return false;
+        }
+        include $file;
 	}
 
 	protected function source($clazz) 
 	{
 		$dir = BASE_PATH. '/modules/source';
 		$this->splitClazz($clazz,$dir);	 
-
-		set_include_path($dir);
-		spl_autoload_extensions('.php');
-		spl_autoload($clazz);
+		$file = "$dir/$clazz.php";
+		if (!file_exists($file))
+        {
+            return false;
+        }
+        include $file;
 	}
 
 	protected function splitClazz(& $clazz, &$baseDir)


### PR DESCRIPTION
Fix error: Class ‘Template’ not found in /tw2other/modules/init/func.inc.php on line 76, and a minor defect in library/renrenoauth.php

For details: http://www.guiguan.net/patches-for-tw2other-1-0-by-cluries-on-github/
